### PR TITLE
VCS versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Custom
+src/pydevdtk/version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "src/pydevdtk/version.py"
 
+[tool.hatch.version.raw-options]
+version_scheme="no-guess-dev"
+
 [tool.hatch.build]
 artifacts = [
   "src/pydevdtk/version.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,11 @@
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = [
+    "hatchling",
+    "hatch-vcs"
+]
 [project]
 name = "PyDevDTK"
-version = "0.1.0"
 authors = [
     { name="Bojan Sofronievski", email="bojan.drago@gmail.com" },
 ]
@@ -15,6 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dynamic = ["version"]
 dependencies = [
     "numpy>=1.23.3",
     "matplotlib>=3.5.2"
@@ -23,6 +26,17 @@ dependencies = [
 [project.urls]
 "Homepage" = "https://github.com/BojanSof/pydevdtk"
 "Bug Tracker" = "https://github.com/BojanSof/pydevdtk/issues"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/pydevdtk/version.py"
+
+[tool.hatch.build]
+artifacts = [
+  "src/pydevdtk/version.py",
+]
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
- Use `hatch-vcs` plugin for git-based versioning of the project